### PR TITLE
Allow to explicitly specify S3 bucket

### DIFF
--- a/rubberjackcli/click.py
+++ b/rubberjackcli/click.py
@@ -39,8 +39,9 @@ def region_from_name(region_name):
 @click.option('--organisation', help="TODO", default="laterpay")
 @click.option('--region', help="TODO", default="eu-central-1")
 @click.option('--sigv4-host', help="TODO", default=None)
+@click.option('--bucket', help="Explicitly specify S3 bucket name for deployment. Otherwise it's '{organisation}-rubberjack-ebdeploy'.", default=None)
 @click.pass_context
-def rubberjack(ctx, application, organisation, region, sigv4_host):
+def rubberjack(ctx, application, organisation, region, sigv4_host, bucket):
     """
     Main entry point into the rubberjack CLI.
     """
@@ -55,7 +56,10 @@ def rubberjack(ctx, application, organisation, region, sigv4_host):
     ctx.obj['dev_environment_name'] = "{application_name}-dev".format(application_name=application_name)
     ctx.obj['live_environment_name'] = "{application_name}-live".format(application_name=application_name)
 
-    ctx.obj['bucket'] = "{organisation}-rubberjack-ebdeploy".format(organisation=organisation)
+    if bucket is None:
+        bucket = "{organisation}-rubberjack-ebdeploy".format(organisation=organisation)
+
+    ctx.obj['bucket'] = bucket
 
     # boto doesn't use a default of None, it uses NoHostProvided, and I struggled to pass that myself
     if sigv4_host:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,6 +89,19 @@ class CLITests(unittest.TestCase):
             self.assertEquals(result.exit_code, 0, result.output)
 
     @moto.mock_s3
+    @mock.patch('boto.beanstalk.layer1.Layer1.create_application_version')
+    @mock.patch('boto.beanstalk.layer1.Layer1.update_environment')
+    def test_deploy_to_custom_bucket(self, cav, ue):
+        bucket_name = 'rbbrjck-test'
+        s3 = boto.connect_s3()
+        s3.create_bucket(bucket_name)
+
+        with tempfile.NamedTemporaryFile() as tmp:
+            result = CliRunner().invoke(rubberjack, ['--bucket', bucket_name, 'deploy', tmp.name], catch_exceptions=False)
+
+            self.assertEquals(result.exit_code, 0, result.output)
+
+    @moto.mock_s3
     @mock.patch('boto.beanstalk.layer1.Layer1.update_environment')
     @mock.patch('boto.beanstalk.layer1.Layer1.describe_environments')
     def test_promote_to_custom_environment(self, de, ue):


### PR DESCRIPTION
Because of weird shenanigans of boto, rubberjack won't be able to deploy application to a different account than the S3 bucket was created in.

Moreover, it has problems with deploying via a user (from the same account that EB app is in) even if the S3 bucket is in the same AWS account, but in a different region (probably some weird permission issue). Nevertheless, I feel like this can be a useful option.

