### PR TITLE
Add `no-update-environment` flag for `deploy`

### DIFF
--- a/rubberjackcli/click.py
+++ b/rubberjackcli/click.py
@@ -72,9 +72,12 @@ def rubberjack(ctx, application, organisation, region, sigv4_host, bucket):
 
 @rubberjack.command()
 @click.option('--environment', default=None)
+@click.option('--update-environment/--no-update-environment', default=True,
+              help="Decide whether to update the environment or only create a version."
+              "--no-update-environment can be useful for manual deployment approval.")
 @click.argument('filename', default="./deploy.zip", type=click.Path(exists=True))
 @click.pass_context
-def deploy(ctx, environment, filename):
+def deploy(ctx, environment, update_environment, filename):
     """
     Do the actual deployment work.
 
@@ -111,7 +114,8 @@ def deploy(ctx, environment, filename):
 
     # Deploy
 
-    beanstalk.update_environment(environment_name=environment, version_label=VERSION)
+    if update_environment:
+        beanstalk.update_environment(environment_name=environment, version_label=VERSION)
 
 
 @rubberjack.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,6 +91,21 @@ class CLITests(unittest.TestCase):
     @moto.mock_s3
     @mock.patch('boto.beanstalk.layer1.Layer1.create_application_version')
     @mock.patch('boto.beanstalk.layer1.Layer1.update_environment')
+    def test_deploy_without_updating_the_environment(self, ue, cav):
+        s3 = boto.connect_s3()
+        s3.create_bucket("laterpay-rubberjack-ebdeploy")  # FIXME Remove hardcoded bucket name
+
+        with tempfile.NamedTemporaryFile() as tmp:
+            result = CliRunner().invoke(rubberjack, ['deploy', '--no-update-environment', tmp.name], catch_exceptions=False)
+
+            self.assertEquals(result.exit_code, 0, result.output)
+
+        self.assertEqual(cav.call_count, 1, "create_application_version wasn't called, but it should")
+        self.assertEqual(ue.call_count, 0, "update_environment was called, but it shouldn't")
+
+    @moto.mock_s3
+    @mock.patch('boto.beanstalk.layer1.Layer1.create_application_version')
+    @mock.patch('boto.beanstalk.layer1.Layer1.update_environment')
     def test_deploy_to_custom_bucket(self, cav, ue):
         bucket_name = 'rbbrjck-test'
         s3 = boto.connect_s3()


### PR DESCRIPTION
Setting `--no-update-environment` will not update the environment on ElastiBeanstalk, but only create the corresponding version. 
This may be useful when we want to have a manual approval step in  our deployment.